### PR TITLE
Fix for legend position in theme_line_dft

### DIFF
--- a/R/themeXDft.R
+++ b/R/themeXDft.R
@@ -186,7 +186,7 @@ theme_line_dft <- function(legend_position = "bottom",
                                 labels = label_number(accuracy = accuracy)),
     ggplot2::expand_limits(y = 0),
     ggplot2::coord_cartesian(clip = 'off'),
-    ggplot2::theme(legend.position = 'none'))
+    ggplot2::theme(legend.position = legend_position))
 
   ##Turn off labelling if required
   if(labels == TRUE){


### PR DESCRIPTION
## Proposed changes

When using theme_line_dft, legend_position would be overwritten to "none" leading to no legend. This PR fixes that.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation Update (change to naming or other documentation)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have checked that my changes have not broken any other functionality
- [ ] I have linked to any issues this PR fixes 

## Points for review

Add checkboxes here for any specific aspects of your PR you would like to be checked in peer review. If you don't specify anything here, the reviewer will check:

- [ ] All of your unit tests pass
- [ ] Your code is clear and easy to understand
- [ ] You have documented any new features
- [ ] They can run the code you have written
- [ ] Your changes do not break any other functionality

## Who is reviewing this PR?

@DIPAD-Fran-Bryden 
